### PR TITLE
ユーザー認証のAPI連携

### DIFF
--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Auth;
+
+class AuthController extends Controller
+{
+    // リクエストを検証してユーザーを作成し、アクセストークンを返す
+  public function register(Request $request)
+  {
+    $validatedData = $request->validate([
+      'name' => 'required|string|max:255',
+      'email' => 'required|string|email|max:255|unique:users',
+      'password' => 'required|string|min:8',
+    ]);
+
+    $user = User::create([
+      'name' => $validatedData['name'],
+      'email' => $validatedData['email'],
+      'password' => Hash::make($validatedData['password']),
+    ]);
+
+    $token = $user->createToken('auth_token')->plainTextToken;
+
+    return response()->json([
+      'access_token' => $token,
+      'token_type' => 'Bearer',
+    ]);
+  }
+  // リクエストを検証してユーザーを認証し、アクセストークンを返す
+  public function login(Request $request)
+  {
+    $request->validate([
+      'email' => 'required|email',
+      'password' => 'required',
+    ]);
+
+    if (!Auth::attempt($request->only('email', 'password'))) {
+      return response()->json([
+        'message' => 'Invalid login details'
+      ], 401);
+    }
+
+    $user = User::where('email', $request['email'])->firstOrFail();
+
+    $token = $user->createToken('auth_token')->plainTextToken;
+
+    return response()->json([
+      'access_token' => $token,
+      'token_type' => 'Bearer',
+    ]);
+  }
+
+  // 認証されたユーザーのアクセストークンを削除してログアウトする
+  public function logout(Request $request)
+  {
+    $request->user()->currentAccessToken()->delete();
+
+    return response()->json(['message' => 'Successfully logged out']);
+  }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,10 +7,12 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
+use Laravel\Sanctum\HasApiTokens;
+
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory, Notifiable, HasApiTokens;
 
     /**
      * The attributes that are mass assignable.

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,18 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
+use App\Http\Controllers\Api\AuthController;
+
+// 登録APIのルート
+Route::post('/register', [AuthController::class, 'register']);
+
+// ログインAPIのルート
+Route::post('/login', [AuthController::class, 'login']);
+
+// ログアウトAPIのルート
+Route::middleware('auth:sanctum')->post('/logout', [AuthController::class, 'logout']);
+
+// 認証されたユーザーの情報を取得するAPIのルート
 Route::middleware(['auth:sanctum'])->get('/user', function (Request $request) {
     return $request->user();
 });


### PR DESCRIPTION
## やったこと
ユーザー認証のAPI連携


## やってないこと
画面表示用のデータを取得するAPIや予約APIなどは今後実装予定です。


## 具体的な変更内容
1. ユーザー認証コントローラーを作成し、ユーザー登録、ログイン処理時にアクセストークンを返す関数を、ログアウト時にはアクセストークンを削除する関数を実装しました。
2. 上記コントローラーをroutes/api.phpのルーティングを追加しました。


### 参考文献・URLなど
特になし


### 【前提として必要な知識・情報】
特になし


## 動作確認
Postmanでユーザー認証のAPI連携の可否を確認してください。



## 該当タスク
GitHub Issue #5 「ユーザー認証APIの実装」