### PR TITLE
トレーナー表示APIの最小版

### DIFF
--- a/app/Http/Controllers/Api/TrainerController.php
+++ b/app/Http/Controllers/Api/TrainerController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Models\Trainer;
+
+class TrainerController extends Controller
+{
+    // トレーナーの一覧を取得するメソッド
+    public function index()
+        {
+            return Trainer::with(['areas', 'categories'])->paginate(10);
+        }
+    // 特定のトレーナーの詳細を取得するメソッド
+    public function show(Trainer $trainer)
+        {
+            return $trainer->load(['areas', 'categories']);
+        }
+}

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Models\Trainer;
 
 class Category extends Model
 {
@@ -12,6 +13,6 @@ class Category extends Model
 
     //トレーナーテーブルとの中間テーブル
     public function trainers() {
-      return $this->belongsToMany(trainer::class)->withTimestamps();
+      return $this->belongsToMany(Trainer::class)->withTimestamps();
     }
 }

--- a/app/Models/Trainer.php
+++ b/app/Models/Trainer.php
@@ -4,6 +4,9 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Models\Category;
+use App\Models\Speciality;
+use App\Models\Area;
 
 class Trainer extends Model
 {

--- a/app/Models/area.php
+++ b/app/Models/area.php
@@ -3,6 +3,8 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use App\Models\Trainer;
+
 
 class Area extends Model
 {

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,6 +4,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
 use App\Http\Controllers\Api\AuthController;
+use App\Http\Controllers\Api\TrainerController;
 
 // 登録APIのルート
 Route::post('/register', [AuthController::class, 'register']);
@@ -18,3 +19,8 @@ Route::middleware('auth:sanctum')->post('/logout', [AuthController::class, 'logo
 Route::middleware(['auth:sanctum'])->get('/user', function (Request $request) {
     return $request->user();
 });
+
+// トレーナー一覧APIのルート
+Route::get('/trainers', [TrainerController::class, 'index']);
+// 特定のトレーナーの詳細APIのルート
+Route::get('/trainers/{trainer}', [TrainerController::class, 'show']);


### PR DESCRIPTION
## やったこと
トレーナー情報の表示API連携


## やってないこと
あくまで最小での実験のため、実際のカラム全てでAPI連携をしていません。

##　具体的な変更内容
1. トレーナーコントローラーを作成
2. トレーナー一覧とトレーナー詳細を取得するにあたり、多対多のリレーションのテーブルを中間テーブルで結合を上記コントローラーで実装
3. ルーティングの実装

### 参考文献・URLなど
特になし


### 【前提として必要な知識・情報】
特になし


## 動作確認
PostmanでGETメソッドを試してみてください。




## 該当タスク
特になし