### PR TITLE
トレーナー登録APIの実装

### DIFF
--- a/app/Http/Controllers/Api/TrainerController.php
+++ b/app/Http/Controllers/Api/TrainerController.php
@@ -3,11 +3,50 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+// リクエストを使用するためにRequestクラスをインポート
 use Illuminate\Http\Request;
 use App\Models\Trainer;
+// トランザクションを使用するためにDBファサードをインポート
+use Illuminate\Support\Facades\DB;
 
 class TrainerController extends Controller
 {
+
+    public function store(Request $request)
+    {
+        // リクエストのバリデーション
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'tel' => 'nullable|string',
+            'birth' => 'nullable|date',
+            'record' => 'nullable|string',
+            'bio' => 'nullable|string',
+            'areas_ids' => 'required|array',
+            'areas_ids.*' => 'exists:areas,id',
+            'categories_ids' => 'required|array',
+            'categories_ids.*' => 'exists:categories,id',
+        ]);
+
+        // トランザクションを使用して、トレーナーの作成と関連付けを一括で行う
+        return DB::transaction(function () use ($validated) {
+            $trainer = Trainer::create([
+                'user_id' => auth()->id(), // 認証されたユーザーのIDを取得
+                'name' => $validated['name'],
+                'tel' => $validated['tel'] ?? null,
+                'birth' => $validated['birth'] ?? null,
+                'record' => $validated['record'] ?? null,
+                'bio' => $validated['bio'] ?? null,
+            ]);
+
+            // トレーナーとエリア、カテゴリーの関連付け
+            $trainer->areas()->attach($validated['areas_ids']);
+            $trainer->categories()->attach($validated['categories_ids']);
+
+            // 作成したトレーナーの情報とリレーションデータを一緒に返す
+            return response()->json($trainer->load(['areas', 'categories']), 201);
+        });
+    }
+
     // トレーナーの一覧を取得するメソッド
     public function index()
         {

--- a/app/Models/City.php
+++ b/app/Models/City.php
@@ -3,9 +3,12 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class City extends Model
 {
+    use HasFactory;
+
     //Prefectureテーブルとの関連
     public function prefecture() {
         return $this->belongsTo(Prefecture::class);

--- a/app/Models/Prefecture.php
+++ b/app/Models/Prefecture.php
@@ -3,9 +3,12 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class Prefecture extends Model
 {
+    use HasFactory;
+    
     //cityテーブルとの関連
     public function cities() {
         return $this->hasMany(City::class);

--- a/app/Models/Trainer.php
+++ b/app/Models/Trainer.php
@@ -13,6 +13,15 @@ class Trainer extends Model
     /** @use HasFactory<\Database\Factories\TrainerFactory> */
     use HasFactory;
 
+    protected $fillable = [
+        'user_id',
+        'name',
+        'tel',
+        'birth',
+        'record',
+        'bio',
+    ];
+
     //ユーザーテーブルとの関連づけ
     public function user() {
         return $this->belongsTo(User::class);

--- a/app/Models/area.php
+++ b/app/Models/area.php
@@ -4,10 +4,12 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use App\Models\Trainer;
-
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class Area extends Model
 {
+    use HasFactory;
+
     //cityテーブルとの関連
     public function city() {
         return $this->belongsTo(City::class);

--- a/database/factories/AreaFactory.php
+++ b/database/factories/AreaFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Area;
+use App\Models\City;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Area>
+ */
+class AreaFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    // 生成するモデルを指定
+    protected $model = Area::class;
+
+    // ダミーデータの定義
+    public function definition()
+    {
+        return [
+            // エリア名をダミーの都市名で生成
+            'name' => $this->faker->city(),
+            'city_id' => City::factory(),
+        ];
+    }
+}

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 namespace Database\Factories;
-
+use App\Models\Category;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -9,15 +9,14 @@ use Illuminate\Database\Eloquent\Factories\Factory;
  */
 class CategoryFactory extends Factory
 {
-    /**
-     * Define the model's default state.
-     *
-     * @return array<string, mixed>
-     */
-    public function definition(): array
+    // 生成するモデルを指定
+    protected $model = Category::class;
+
+    // ダミーデータの定義
+    public function definition()
     {
         return [
-            //
+            'name' => $this->faker->word(),
         ];
     }
 }

--- a/database/factories/CityFactory.php
+++ b/database/factories/CityFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Prefecture;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\City>
+ */
+class CityFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            // 都市名をダミーの都市名で生成
+            'name' => $this->faker->city(),
+            'prefecture_id' => Prefecture::factory(),
+        ];
+    }
+}

--- a/database/factories/PrefectureFactory.php
+++ b/database/factories/PrefectureFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Prefecture>
+ */
+class PrefectureFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            //
+            'name' => $this->faker->state(), 
+        ];
+    }
+}

--- a/database/factories/TrainerFactory.php
+++ b/database/factories/TrainerFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\Trainer;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -14,10 +15,18 @@ class TrainerFactory extends Factory
      *
      * @return array<string, mixed>
      */
+    protected $model = Trainer::class;
+
     public function definition(): array
     {
         return [
-            //
+            // トレーナーの情報をダミーデータで生成
+            'name' => $this->faker->name(),
+            'tel' => $this->faker->phoneNumber(),
+            'birth' => $this->faker->date(),
+            'record' => $this->faker->sentence(),
+            'bio' => $this->faker->paragraph(),
+            'user_id' => 1, // テスト用に固定
         ];
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,9 @@ namespace Database\Seeders;
 use App\Models\User;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use App\Models\Area;
+use App\Models\Category;
+use App\Models\Trainer;
 
 class DatabaseSeeder extends Seeder
 {
@@ -21,5 +24,15 @@ class DatabaseSeeder extends Seeder
             'name' => 'Test User',
             'email' => 'test@example.com',
         ]);
+
+        // Areas と Categories を作成
+        $areas = Area::factory()->count(3)->create();
+        $categories = Category::factory()->count(3)->create();
+
+        // Trainers を作成して中間テーブルに紐付け
+        Trainer::factory()->count(5)->create()->each(function($trainer) use ($areas, $categories) {
+            $trainer->areas()->attach($areas->pluck('id')->toArray());
+            $trainer->categories()->attach($categories->pluck('id')->toArray());
+        });        
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,7 +20,12 @@ Route::middleware(['auth:sanctum'])->get('/user', function (Request $request) {
     return $request->user();
 });
 
-// トレーナー一覧APIのルート
-Route::get('/trainers', [TrainerController::class, 'index']);
-// 特定のトレーナーの詳細APIのルート
-Route::get('/trainers/{trainer}', [TrainerController::class, 'show']);
+Route::middleware('auth:sanctum')->group(function () {
+
+    Route::post('/trainers', [TrainerController::class, 'store']);
+
+    // トレーナー一覧APIのルート
+    Route::get('/trainers', [TrainerController::class, 'index']);
+    // 特定のトレーナーの詳細APIのルート
+    Route::get('/trainers/{trainer}', [TrainerController::class, 'show']);
+});


### PR DESCRIPTION
## やったこと
トレーナー登録APIの実装


## やってないこと
Speciality_Trainerテーブルとの関連付け


##　具体的な変更内容

1. コントローラーにstoreメソッドを追加（添付ファイル参照）
<img width="753" height="711" alt="スクリーンショット 2026-02-26 22 34 05" src="https://github.com/user-attachments/assets/e295d0e5-4217-45c8-84d8-7c97c0455d8b" />

2. ルーティングにstoreを追加

3. ファクトリにfacerを定義

4. シーダーにダミーデータのルールを設定 

5. Postmanでテスト


### 参考文献・URLなど
特になし

### 【前提として必要な知識・情報】
特になし

## 動作確認
1. Postmanでurl~/storeにPOSTでデータを送ってみてください。



## 該当タスク
GitHub Issue #9「トレーナー登録APIの実装」