### PR TITLE
画像登録

### DIFF
--- a/app/Http/Controllers/Api/TrainerController.php
+++ b/app/Http/Controllers/Api/TrainerController.php
@@ -8,6 +8,8 @@ use Illuminate\Http\Request;
 use App\Models\Trainer;
 // トランザクションを使用するためにDBファサードをインポート
 use Illuminate\Support\Facades\DB;
+// ストレージを使用するためにStorageファサードをインポート
+use Illuminate\Support\Facades\Storage;
 
 class TrainerController extends Controller
 {
@@ -27,10 +29,11 @@ class TrainerController extends Controller
             'categories_ids.*' => 'exists:categories,id',
             'specialities_ids' => 'required|array',
             'specialities_ids.*' => 'exists:specialities,id',
+            'profile_image' => 'nullable|image|max:2048', // 2MBまで
         ]);
 
         // トランザクションを使用して、トレーナーの作成と関連付けを一括で行う
-        return DB::transaction(function () use ($validated) {
+        return DB::transaction(function () use ($validated, $request) {
             // トレーナーの作成
             $trainer = Trainer::create([
                 'user_id' => auth()->id(), // 認証されたユーザーのIDを取得
@@ -41,21 +44,22 @@ class TrainerController extends Controller
                 'bio' => $validated['bio'] ?? null,
             ]);
 
+
+            // 画像があれば保存
+            if ($request->hasFile('profile_image')) {
+                // 画像をpublicディスクのtrainersディレクトリに保存
+                $path = $request->file('profile_image')
+                                ->store('trainers', 'public');
+                // 保存した画像のパスをトレーナーのprofile_imageカラムに保存
+                $trainer->update([
+                    'profile_image' => $path
+                ]);
+            }
+
             // belongsToManyのリレーションを使用して、areasとcategoriesの関連付けを行う
             $trainer->areas()->attach($validated['areas_ids']);
             $trainer->categories()->attach($validated['categories_ids']);
             $trainer->specialities()->attach($validated['specialities_ids']);
-
-            // 画像があれば保存
-            if ($request->hasFile('profile_image')) {
-
-                $path = $request->file('profile_image')
-                                ->store('trainers', 'public');
-
-                $trainer->profile_image = $path;
-            }
-
-            $trainer->save();
 
 
             // 作成したトレーナーの情報とリレーションデータを一緒に返す

--- a/app/Models/Trainer.php
+++ b/app/Models/Trainer.php
@@ -20,6 +20,7 @@ class Trainer extends Model
         'birth',
         'record',
         'bio',
+        'profile_image',
     ];
 
     //ユーザーテーブルとの関連づけ


### PR DESCRIPTION
## やったこと
画像をバックエンドで保存処理


## やってないこと
保存した画像の表示処理

##　具体的な変更内容
1. Trainersテーブルにパスを保存するカラムを追加しました。
2. コントローラーの登録処理に画像のバリデーションおよびStorageに保存する処理を行い、Storageをimportしました。
3. Trainerモデルファイルに画像カラムを追加
4. Storageの公開
5. Postmanでテスト

### 参考文献・URLなど
特になし

## 動作確認
Postmanのform-dataでprofile_imageに対して画像を送信してみてください。




## 該当タスク
GitHub Issue#13画像登録処理